### PR TITLE
Fix find_perm locatability

### DIFF
--- a/PermComb/permcomb/concurrent_perm.h
+++ b/PermComb/permcomb/concurrent_perm.h
@@ -64,7 +64,10 @@ bool remove_element( uint32_t elem, uint32_t& remove_value, std::list<uint32_t>&
 
 	return false;
 }
-
+template<typename int_type>
+bool find_perm(uint32_t set_size, 
+			  int_type index_to_find, 
+			  std::vector<uint32_t>& results );
 template<typename int_type, typename vector_type>
 vector_type find_perm_by_idx(int_type index_to_find,
 	vector_type& original_vector)


### PR DESCRIPTION
This fix resolves an error when compiling

the error being:
```
/src/concurrentperm.h:74:5: error: call to function 'find_perm' that is neither visible in the template definition nor found by argument-dependent lookup
if (find_perm((original_vector.size()), index_to_find, integer_results))

note: 'find_perm' should be declared prior to the call site
```